### PR TITLE
feat(api): `_selected_devices` reset when using `select_device_id()`

### DIFF
--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,10 +1,10 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.9%</title>
+    <title>interrogate: 95.1%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
         </g>
-        <rect x="71" y="0" width="47" height="20" data-interrogate="color" style="fill:#97CA00"/>
+        <rect x="71" y="0" width="47" height="20" data-interrogate="color" style="fill:#4c1"/>
         <g transform="matrix(1.19746,0,0,1,-22.3744,-4.85723e-16)">
             <rect x="0" y="0" width="118" height="20" style="fill:url(#_Linear1);"/>
         </g>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.9%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.9%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">95.1%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">95.1%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/src/qiboconnection/api.py
+++ b/src/qiboconnection/api.py
@@ -1,4 +1,4 @@
-""" Qilimanjaro Client API to communicate with the Qilimanajaro Global Quantum Services """
+""" Qilimanjaro Client API to communicate with the Qilimanjaro Global Quantum Services """
 import json
 from abc import ABC
 from dataclasses import asdict
@@ -142,6 +142,7 @@ class API(ABC):
             device_id (int): Device identifier
 
         """
+        self._selected_devices = []
         self._devices = self._add_or_update_single_device(device_id=device_id)
         try:
             selected_device = self._devices.select_device(device_id=device_id)
@@ -244,7 +245,7 @@ class API(ABC):
             experiment (dict): an Experiment description, result of Qililab's Experiment().to_dict() function.
             nshots (int): number of times the execution is to be done.
             device_ids (List[int]): list of devices where the execution should be performed. If set, any device set
-             using API.select_device_id() will not be used. This will not update the selecte
+             using API.select_device_id() will not be used. This will not update the selected devices.
 
         Returns:
             List[int]: list of job ids
@@ -409,7 +410,7 @@ class API(ABC):
     ):
         """Sends point(s) to a specific plot.
         Args:
-            plot_id: Id of the plot to send points to
+            plot_id: id of the plot to send points to
             x: x coord of the point to send info to
             y: y coord of the point to send info to
             z: z coord of the point to send info to


### PR DESCRIPTION
Selected devices list is set to a blank list when calling  both `_select_device_id(id: int)` and `select_device_ids(ids: List[int])` (previously implemented)