### PR TITLE
feat(API): added user comodity login constructor

### DIFF
--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 95.7%</title>
+    <title>interrogate: 96.5%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">95.7%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">95.7%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">96.5%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">96.5%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/src/qiboconnection/api.py
+++ b/src/qiboconnection/api.py
@@ -174,6 +174,20 @@ class API(ABC):
         self._saved_experiments_listing: SavedExperimentListing | None = None
         self._runcard: Runcard | None = None
 
+    @classmethod
+    def login(cls, username: str, api_key: str):
+        """Log into QaaS using your username and api_key
+
+        Args:
+            username: username of your account
+            api_key: you access key
+
+        Returns:
+            Authenticated API instance
+        """
+        _configuration = ConnectionConfiguration(username=username, api_key=api_key)
+        return cls(configuration=_configuration)
+
     """ LOCAL INFORMATION """
 
     @property

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from qiboconnection.api import API
+from qiboconnection.connection import ConnectionConfiguration
 from qiboconnection.errors import ConnectionException, RemoteExecutionException
 from qiboconnection.models.devices.devices import Devices
 from qiboconnection.models.devices.util import create_device
@@ -24,6 +25,21 @@ from .utils import get_current_event_loop_or_create
 def test_api_constructor(mocked_api: API):
     """Test API class constructor"""
     assert isinstance(mocked_api, API)
+
+
+@patch("qiboconnection.api.API.__init__", autospec=True)
+def test_api_login(mocked_api_init: MagicMock):
+    """Tests user utility constructor Login calls __init__ with the correct information,"""
+    mocked_api_init.return_value = None
+    _USERNAME = "test-name"
+    _API_KEY = "test-key"
+
+    _ = API.login(username=_USERNAME, api_key=_API_KEY)
+
+    provided_user_info = mocked_api_init.call_args_list[0][1]["configuration"]
+    assert type(provided_user_info) is ConnectionConfiguration
+    assert provided_user_info.username == _USERNAME
+    assert provided_user_info.api_key == _API_KEY
 
 
 def test_jobs(mocked_api: API):


### PR DESCRIPTION
Adds `login`,  a new constructor for the `API` class. Allows user to log into our services without importing `ConnectionConfiguration`, as shown here:

```python

api = API.login(username="my-username", api_key="my-key")
```
