### PR TITLE
Removed logging config imposed by the library

### DIFF
--- a/changelog-dev.md
+++ b/changelog-dev.md
@@ -9,6 +9,9 @@ This document contains the changes of the current release.
 
 ### Improvements
 
+- Removed `qiboconnection`'s own logging configuration
+  [#91](https://github.com/qilimanjaro-tech/qiboconnection/pull/91)
+
 ### Breaking changes
 
 ### Deprecations / Removals

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 95.4%</title>
+    <title>interrogate: 95.5%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">95.4%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">95.4%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">95.5%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">95.5%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/src/qiboconnection/config.py
+++ b/src/qiboconnection/config.py
@@ -20,26 +20,7 @@ from typing import Literal, Union
 
 from qiboconnection import __version__
 
-# Logging level from 0 (NOT SET) to 50 (critical) (see https://docs.python.org/3/library/logging.html#logging-levels)
-QIBO_CLIENT_LOG_LEVEL = int(os.environ.get("QIBO_CLIENT_LOG_LEVEL", 20))
-
-# Configuration for logging mechanism
-
-
-class CustomHandler(logging.StreamHandler):
-    """Custom handler for logging algorithm."""
-
-    def format(self, record):
-        """Format the record with specific format."""
-        fmt = f"[qibo-connection] {__version__}|%(levelname)s|%(asctime)s]: %(message)s"
-        return logging.Formatter(fmt, datefmt="%Y-%m-%d %H:%M:%S").format(record)
-
-
-# allocate logger object
 logger = logging.getLogger(__name__)
-logger.setLevel(QIBO_CLIENT_LOG_LEVEL)
-logger.addHandler(CustomHandler())
-
 
 QUANTUM_SERVICE_URL = {
     "local": "http://localhost:8080",


### PR DESCRIPTION

To facilitate log scrapping and user logging customization, qiboconnection should NOT configure its own logger.

A possible user integration could look like this:

```python
import logging

logger = logging.getLogger()
logger.setLevel(logging.DEBUG)

handler = logging.StreamHandler(sys.stdout)
handler.setLevel(logging.DEBUG)
formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
handler.setFormatter(formatter)
logger.addHandler(handler)

from qiboconnection.api import API
import logging
import sys

api = API.login(username="user", api_key="apikey")
logger.info("connection established")

ids = api.execute( ... )
logger.info(f"jobs sent with ids {', '.join(str(id) for id in ids)}}")

```