### PR TITLE
fix(connection): error message hiding in auth get

### DIFF
--- a/src/qiboconnection/connection.py
+++ b/src/qiboconnection/connection.py
@@ -369,7 +369,6 @@ class Connection(ABC):  # pylint: disable=too-many-instance-attributes
             error_details = response.json()
             if "detail" in error_details and "does not exist" in error_details["detail"]:
                 raise RemoteExecutionException("The job does not exist!", status_code=400)
-            response.raise_for_status()
 
         return process_response(response)
 


### PR DESCRIPTION
This line was hiding the "minimum client version required" error

Behaviour after removal:
```bash
Traceback (most recent call last):
  File "/home/javi/Documents/qilimanjaro/projects/qiboconnection/src/qiboconnection/errors.py", line 73, in custom_raise_for_status
    raise HTTPError(json.dumps(json_text, indent=2), response=response)
requests.exceptions.HTTPError: {
  "title": "Upgrade Required",
  "status": 426,
  "detail": "Client Version (0.13.3) < Client Version required by the method (0.14.2) 426 Client Error:  for url: https://qilimanjaroqaas.ddns.net:8080/api/v1/jobs/1234"
}
```