### PR TITLE
Change name of client version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### New features since last release
 
-- Qiboconnection adds in the header the field **X-Client-Version** that can be checked by the API.
+- Qiboconnection adds in the header the field **ClientVersion** that can be checked by the API.
   [#100](https://github.com/qilimanjaro-tech/qiboconnection/pull/100)
 
 ## 0.13.1

--- a/src/qiboconnection/connection.py
+++ b/src/qiboconnection/connection.py
@@ -172,7 +172,7 @@ class Connection(ABC):  # pylint: disable=too-many-instance-attributes
         self._authorisation_server_refresh_api_call = f"{self._remote_server_api_url}/authorisation-tokens/refresh"
 
     def _add_version_header(self, header):
-        header["X-Client-Version"] = VERSION
+        header["ClientVersion"] = VERSION
         return header
 
     def _load_configuration(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -141,7 +141,7 @@ def test_send_put_auth_remote_api_call(mocked_rest_call: MagicMock, mocked_conne
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -163,7 +163,7 @@ def test_send_post_auth_remote_api_call(mocked_rest_call: MagicMock, mocked_conn
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -185,7 +185,7 @@ def test_send_get_auth_remote_api_call(mocked_rest_call: MagicMock, mocked_conne
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -217,7 +217,7 @@ def test_send_delete_auth_remote_api_call(mocked_rest_call: MagicMock, mocked_co
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -240,7 +240,7 @@ def test_send_delete_auth_remote_api_call_not_204_not_job_details(
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -261,7 +261,7 @@ def test_send_delete_auth_remote_api_call_not_204_with_job_details(
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )
@@ -285,7 +285,7 @@ def test_send_post_file_auth_remote_api_call(mocked_rest_call: MagicMock, mocked
             "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ"
             ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=_TIMEOUT,
     )
@@ -332,7 +332,7 @@ def test_send_get_remote_call(mocked_rest_call: MagicMock, mocked_connection: Co
     response, code = mocked_connection.send_get_remote_call(path="/PATH", timeout=10)
 
     mocked_rest_call.assert_called_with(
-        f"{mocked_connection._remote_server_base_url}/PATH", timeout=10, headers={"X-Client-Version": __version__}
+        f"{mocked_connection._remote_server_base_url}/PATH", timeout=10, headers={"ClientVersion": __version__}
     )
     assert response == web_responses.raw.response_200.json()
     assert code == web_responses.raw.response_200.status_code
@@ -442,7 +442,7 @@ def test_update_authorisation_using_refresh_token(mocked_rest_call: MagicMock, m
                 + "LCJ0eXBlIjoicmVmcmVzaCIsInVzZXJfaWQiOjMsInVzZXJfcm9sZSI6ImFkbWluIn0"
                 + ".4oSyRW9Ia7C-50x2yZxQAEXDZp-TLkFkPOtHBR4cCi9LnkREtYrJpDXufep_EYoRwDSJL_2z20moYMuMHy0QCg"
             ),
-            "X-Client-Version": __version__,
+            "ClientVersion": __version__,
         },
         timeout=10,
     )


### PR DESCRIPTION
Had to change the name from X-Client-Version to ClientVersion because apiflask schema's doesn't let define headers with -. 
![image](https://github.com/qilimanjaro-tech/qiboconnection/assets/104149115/8f82e55c-7c83-44f2-b64d-34c71fb85ac9)
On the other hand, couldn't be renamed X_Client_Version because nginx ignores hyphens in headers by default despite HTTP supports this.https://www.grouparoo.com/blog/dont-use-underscores-in-http-headers 